### PR TITLE
Adding parameters for reading the mass window from the config file.

### DIFF
--- a/interface_mibio/control_mibio_process.py
+++ b/interface_mibio/control_mibio_process.py
@@ -71,8 +71,8 @@ def edit_config(bg_thres_ev,bg_thres_au,bg_thres_ta):
     with open(params.config_file_path, 'r+') as config_file:
         json_data = json.load(config_file)
         # select mass window
-        json_data['Generator.DefaultMassStart'] = -0.3
-        json_data['Generator.DefaultMassStop'] = 0.0
+        json_data['Generator.DefaultMassStart'] = params.mass_start
+        json_data['Generator.DefaultMassStop'] = params.mass_stop
         # initialize the auto bg removal options (no bg removal)
         json_data['Generator.BackgroundRemovalAuto.events'] = False
         json_data['Generator.BackgroundRemovalAuto.197'] = False

--- a/interface_mibio/params_bg.py
+++ b/interface_mibio/params_bg.py
@@ -15,6 +15,10 @@ recalibrate_mass =                  False
 config_file_path =                  mibio_helper_files_dir_path.joinpath('mibio_config.json')                                   
 log_file_path =                     mibio_helper_files_dir_path.joinpath('mibio.log')                                       
 
+# mass window
+mass_start = -0.3
+mass_stop = 0
+
 # best to set output_file_name to last FOV in array
 output_file_name =                  f'Point{fovs[-1]}_RowNumber0_Depth_Profile0.tiff'            
 output_tiff_path =                  xml_path.parent.joinpath(xml_path.stem).joinpath(str(xml_path.stem) + '_TIFF')  


### PR DESCRIPTION
With this PR, the mass window can be specified in the parameters config file, rather than having to edit the main script calling MIBI/O.